### PR TITLE
Move function and var definitions to the top level

### DIFF
--- a/hideshowvis.el
+++ b/hideshowvis.el
@@ -125,6 +125,43 @@ this value (in bytes).  The minor mode can still be forced to be enabled using
   :group 'hideshow
   :type 'integer)
 
+(defcustom hideshowvis-hidden-fringe-face 'hideshowvis-hidden-fringe-face
+  "*Specify face used to highlight the fringe on hidden regions."
+  :type 'face
+  :group 'hideshow)
+
+(defface hideshowvis-hidden-fringe-face
+  '((t (:foreground "#888" :box (:line-width 2 :color "grey75" :style released-button))))
+  "Face used to highlight the fringe on folded regions"
+  :group 'hideshow)
+
+(defcustom hideshowvis-hidden-region-face 'hideshowvis-hidden-region-face
+  "*Specify the face to to use for the hidden region indicator"
+  :type 'face
+  :group 'hideshow)
+
+(defface hideshowvis-hidden-region-face
+  '((t (:background "#ff8" :box t)))
+  "Face to hightlight the ... area of hidden regions"
+  :group 'hideshow)
+
+(define-fringe-bitmap 'hideshowvis-hidden-marker [0 24 24 126 126 24 24 0])
+
+(defun hideshowvis-display-code-line-counts (ov)
+  (when (eq 'code (overlay-get ov 'hs))
+    (let* ((marker-string "*fringe-dummy*")
+           (marker-length (length marker-string))
+           (display-string (format "(%d)..." (count-lines (overlay-start ov) (overlay-end ov))))
+           )
+      (overlay-put ov 'help-echo "Hidden text. C-c,= to show")
+      (put-text-property 0 marker-length 'display
+                         (list 'left-fringe 'hideshowvis-hidden-marker 'hideshowvis-hidden-fringe-face)
+                         marker-string)
+      (overlay-put ov 'before-string marker-string)
+      (put-text-property 0 (length display-string) 'face 'hideshowvis-hidden-region-face display-string)
+      (overlay-put ov 'display display-string))))
+
+
 (defun hideshowvis-highlight-hs-regions-in-fringe (&optional start end _old-text-length)
   "Will update the fringe indicators for all foldable regions in the buffer.
 This can be slow for large buffers.  Adjust `hideshowvis-max-file-size' when
@@ -232,43 +269,6 @@ indicating the number of hidden lines at the end of the line for hidden regions.
 This will change the value of `hs-set-up-overlay' so it will
 overwrite anything you've set there."
   (interactive)
-  
-  (define-fringe-bitmap 'hideshowvis-hidden-marker [0 24 24 126 126 24 24 0])
-  
-  (defcustom hideshowvis-hidden-fringe-face 'hideshowvis-hidden-fringe-face
-    "*Specify face used to highlight the fringe on hidden regions."
-    :type 'face
-    :group 'hideshow)
-  
-  (defface hideshowvis-hidden-fringe-face
-    '((t (:foreground "#888" :box (:line-width 2 :color "grey75" :style released-button))))
-    "Face used to highlight the fringe on folded regions"
-    :group 'hideshow)
-  
-  (defcustom hideshowvis-hidden-region-face 'hideshowvis-hidden-region-face
-    "*Specify the face to to use for the hidden region indicator"
-    :type 'face
-    :group 'hideshow)
-  
-  (defface hideshowvis-hidden-region-face
-    '((t (:background "#ff8" :box t)))
-    "Face to hightlight the ... area of hidden regions"
-    :group 'hideshow)
-
-  (defun hideshowvis-display-code-line-counts (ov)
-    (when (eq 'code (overlay-get ov 'hs))
-      (let* ((marker-string "*fringe-dummy*")
-             (marker-length (length marker-string))
-             (display-string (format "(%d)..." (count-lines (overlay-start ov) (overlay-end ov))))
-             )
-        (overlay-put ov 'help-echo "Hiddent text. C-c,= to show")
-        (put-text-property 0 marker-length 'display
-                           (list 'left-fringe 'hideshowvis-hidden-marker 'hideshowvis-hidden-fringe-face)
-                           marker-string)
-        (overlay-put ov 'before-string marker-string)
-        (put-text-property 0 (length display-string) 'face 'hideshowvis-hidden-region-face display-string)
-        (overlay-put ov 'display display-string))))
-  
   (setq hs-set-up-overlay 'hideshowvis-display-code-line-counts))
 
 (provide 'hideshowvis)


### PR DESCRIPTION
As discussed in https://github.com/melpa/melpa/pull/5738, it's broken to only define these vars when the function is called (and, worse, to redefine them if the function is called twice). This change fixes that, and should preserve the existing behaviour.