### PR TITLE
fix: Fix warning about define-minor-mode.

### DIFF
--- a/hideshowvis.el
+++ b/hideshowvis.el
@@ -191,7 +191,7 @@ functions used with `after-change-functions'."
   "Keymap for hideshowvis mode.")
 
 ;;;###autoload
-(define-minor-mode hideshowvis-minor-mode ()
+(define-minor-mode hideshowvis-minor-mode
   "Will indicate regions foldable with hideshow in the fringe."
   :init-value nil
   :require 'hideshow


### PR DESCRIPTION
When loading hideshowvis, this warning appears in the messages:

```
hideshowvis.el: Warning: Use keywords rather than deprecated positional arguments to ‘define-minor-mode’
```

This is because there are unnecessary parens in the code and they are being treated as an argument.  Removing them fixes the warning.